### PR TITLE
block creation logic update

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,11 @@ p2p_port = 4444
 client_port = 8089
 client_host = "0.0.0.0"
 client_apps = ["./libdoc_app.so", "./libwallet_app.so"]
+block_creation_time_limit = 300 # in micro seconds
+block_transaction_limit = 20 # max transaction count in a block
+transaction_execution_delay_limit = 300 # in micro seconds
+
 
 # [consensus]
 public_keys = ["2c8a35450e1d198e3834d933a35962600c33d1d0f8f6481d6e08f140791374d0"]
+

--- a/config.toml
+++ b/config.toml
@@ -7,9 +7,9 @@ p2p_port = 4444
 client_port = 8089
 client_host = "0.0.0.0"
 client_apps = ["./libdoc_app.so", "./libwallet_app.so"]
-block_creation_time_limit = 300 # in micro seconds
+block_creation_time_limit = 3000 # in milliseconds
 block_transaction_limit = 20 # max transaction count in a block
-transaction_execution_delay_limit = 300 # in micro seconds
+transaction_execution_delay_limit = 60000 # in milliseconds
 
 
 # [consensus]

--- a/src/consensus/src/consensus_interface.rs
+++ b/src/consensus/src/consensus_interface.rs
@@ -152,8 +152,10 @@ impl Consensus {
         // schema operations and p2p module
         let fork = fork_db();
         {
-            let mut schema = SchemaFork::new(&fork);
-            let signed_block = schema.create_block(&self.keypair);
+            let schema = SchemaFork::new(&fork);
+            // let signed_block = schema.create_block(&self.keypair);
+            let (fork_instance, signed_block) = schema.forge_new_block(&self.keypair);
+            //fork = fork_instance;
             info!(
                 "new block created.. id {},hash {}",
                 signed_block.block.id,
@@ -170,8 +172,9 @@ impl Consensus {
             ConsensusMessageSender::send_election_ping_msg(sender, msg);
             info!("pinging for block number {}", self.round_number + 1);
             thread::sleep(Duration::from_micros(1000));
+            patch_db(fork_instance);
         }
-        patch_db(fork);
+        //patch_db(fork);
         let signed_new_leader: SignedLeaderElection = self.select_leader(meta_data);
         self.round_number = self.round_number + 1;
         let flag: bool = signed_new_leader.leader_payload.new_leader.clone()

--- a/src/schema/src/transaction_pool.rs
+++ b/src/schema/src/transaction_pool.rs
@@ -7,14 +7,16 @@ use exonum_merkledb::{
     access::{Access, RawAccessMut},
     ObjectHash,
 };
-
 use sdk::traits::{PoolTrait, StateContext};
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+use utils::configreader;
+use utils::configreader::{BlockConfig, Configuration};
 pub type TxnPoolKeyType = u128;
 pub type TxnPoolValueType = SignedTransaction;
 
-trait TransactionPoolTraits {
+pub trait TransactionPoolTraits {
     fn new() -> Self;
     fn delete_txn_hash(&mut self, key: &Hash);
     fn delete_txn_order(&mut self, key: &TxnPoolKeyType);
@@ -167,35 +169,49 @@ impl<T: Access> PoolTrait<T, State, SignedTransaction> for TransactionPool
 where
     T::Base: RawAccessMut,
 {
-    fn execute_transactions(&self, state_context: &mut dyn StateContext) -> Vec<Hash> {
+    fn execute_transactions(&self, state_context: &mut dyn StateContext) -> (Vec<Hash>, Vec<Hash>) {
         let mut temp_vec: Vec<Hash> = Vec::with_capacity(15);
         // compute until order_pool exhusted or transaction limit crossed
         // let txn_pool = self.pool.lock().unwrap();
-        for (_key, sign_txn) in self.order_pool.iter() {
-            if temp_vec.len() < 15 {
-                match APPDATA.lock().unwrap().appdata.get(&sign_txn.app_name) {
-                    Some(app) => {
-                        app.lock().unwrap().execute(sign_txn, state_context);
-                        temp_vec.push(sign_txn.object_hash());
-                        debug!(
-                            "transaction with hash {:?} executed",
-                            sign_txn.object_hash()
-                        );
-                    }
-                    None => {
-                        temp_vec.push(sign_txn.object_hash());
-                        debug!(
-                            "transaction with hash {:?} executed",
-                            sign_txn.object_hash()
-                        );
-                        warn!("unknown app transaction came for execution");
+
+        let block_config: &BlockConfig = &configreader::GLOBAL_CONFIG.block_config;
+        // delayed transaction & transaction from unknown app will be added
+        // in this list. This list will be used to sync-up txn_pool.
+        let mut remove_txn_list: Vec<Hash> = Vec::new();
+        let current_timestamp: TxnPoolKeyType = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_micros();
+        for (timestamp, sign_txn) in self.order_pool.iter() {
+            if temp_vec.len() < block_config.block_transaction_limit as usize {
+                let txn_hash: Hash = sign_txn.object_hash();
+                // check is transaction already added in the previously
+                if !state_context.contains_txn(&txn_hash) {
+                    let timestamp: TxnPoolKeyType = timestamp.clone();
+                    if current_timestamp
+                        > (timestamp + block_config.transaction_execution_delay_limit)
+                    {
+                        remove_txn_list.push(txn_hash);
+                    } else if current_timestamp > timestamp {
+                        match APPDATA.lock().unwrap().appdata.get(&sign_txn.app_name) {
+                            Some(app) => {
+                                app.lock().unwrap().execute(sign_txn, state_context);
+                                temp_vec.push(txn_hash);
+                                debug!("transaction with hash {:?} executed", txn_hash);
+                            }
+                            None => {
+                                remove_txn_list.push(txn_hash);
+                                debug!("transaction with hash {:?} executed", txn_hash);
+                                info!("unknown app transaction came for execution");
+                            }
+                        }
                     }
                 }
             } else {
                 break;
             }
         }
-        temp_vec
+        (temp_vec, remove_txn_list)
     }
 
     fn update_transactions(

--- a/src/sdk/src/traits.rs
+++ b/src/sdk/src/traits.rs
@@ -18,7 +18,7 @@ pub trait AppHandler {
 }
 
 pub trait PoolTrait<T: Access, StateObj, TransactionObj> {
-    fn execute_transactions(&self, state_context: &mut dyn StateContext) -> Vec<Hash>;
+    fn execute_transactions(&self, state_context: &mut dyn StateContext) -> (Vec<Hash>, Vec<Hash>);
     fn update_transactions(
         &self,
         state_context: &mut dyn StateContext,

--- a/src/utils/src/configreader.rs
+++ b/src/utils/src/configreader.rs
@@ -36,6 +36,7 @@ pub enum NODETYPE {
     FullNode,
     Validator,
 }
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TomlReaderConfig {
     pub public: String,
@@ -50,6 +51,10 @@ pub struct TomlReaderConfig {
     client_port: u32,
     client_host: String,
     client_apps: Vec<String>,
+    //block config
+    block_creation_time_limit: u64,
+    block_transaction_limit: u64,
+    transaction_execution_delay_limit: u64,
 }
 
 #[derive(Debug)]
@@ -60,6 +65,9 @@ pub struct Configuration {
 
     //Database config
     pub db: Database,
+
+    // block creation config
+    pub block_config: BlockConfig,
 }
 
 impl Configuration {
@@ -90,12 +98,21 @@ impl Configuration {
         let db_path: Database = Database {
             dbpath: "utils/rocksdb".to_string(),
         };
+        let delay_in_micros: u128 = 1000 * tomlreader.transaction_execution_delay_limit as u128;
+        let time_limit_for_block: u128 = 1000 * tomlreader.block_creation_time_limit as u128;
+        let block_config: BlockConfig = BlockConfig {
+            block_creation_time_limit: time_limit_for_block,
+            block_transaction_limit: tomlreader.block_transaction_limit,
+            transaction_execution_delay_limit: delay_in_micros,
+        };
         let conf_obj = Configuration {
             node: node_obj,
             db: db_path,
+            block_config,
         };
         conf_obj
     }
+
     pub fn init_config() -> TomlReaderConfig {
         // get Current Directory
         let cwd: String = match env::current_dir() {
@@ -140,6 +157,13 @@ pub struct Node {
 #[derive(Debug)]
 pub struct Database {
     pub dbpath: String,
+}
+
+#[derive(Debug)]
+pub struct BlockConfig {
+    pub block_creation_time_limit: u128,         // in micro seconds
+    pub block_transaction_limit: u64,            // max transaction count in a block
+    pub transaction_execution_delay_limit: u128, // in micro seconds
 }
 
 pub fn initialize_config(file_path: &str) {


### PR DESCRIPTION
Block creation logic update tech-dept fix. #44
Please review and merge the PR.
this PR improves block creation logic. Block will be created when either of this is fulfilled
    a. block creation time limit exceed.
    b. max transaction limit fulfilled.

Note: Empty Block case should be handled by the consensus.
Ex→ force-sealing = true / false
